### PR TITLE
Allow setting of a bind address.

### DIFF
--- a/MultiPaper-Master/src/main/java/puregero/multipaper/server/MultiPaperServer.java
+++ b/MultiPaper-Master/src/main/java/puregero/multipaper/server/MultiPaperServer.java
@@ -5,6 +5,7 @@ import puregero.multipaper.server.proxy.ProxyServer;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,13 +23,20 @@ public class MultiPaperServer extends Thread {
     public static final String SECRET = UUID.randomUUID().toString();
 
     public static void main(String[] args) throws IOException {
+        InetAddress address = InetAddress.getByName("0.0.0.0");
         int port = DEFAULT_PORT;
 
         if (args.length > 0) {
             try {
-                port = Integer.parseInt(args[0]);
+                if (args[0].contains(":")) {
+                    String[] split = args[0].split(":", 2);
+                    address = InetAddress.getByName(split[0]);
+                    port = Integer.parseInt(split[1]);
+                } else {
+                    port = Integer.parseInt(args[0]);
+                }
             } catch (NumberFormatException e) {
-                System.err.println("Usage: java -jar MultiPaperServer.jar <port> [proxy port]");
+                System.err.println("Usage: java -jar MultiPaperServer.jar <address>:<port> [proxy port]");
                 System.exit(1);
             }
         }
@@ -37,20 +45,20 @@ public class MultiPaperServer extends Thread {
             try {
                 ProxyServer.openServer(Integer.parseInt(args[1]));
             } catch (NumberFormatException e) {
-                System.err.println("Usage: java -jar MultiPaperServer.jar <port> [proxy port]");
+                System.err.println("Usage: java -jar MultiPaperServer.jar <address>:<port> [proxy port]");
                 System.exit(1);
             }
         }
 
-        new MultiPaperServer(port).start();
+        new MultiPaperServer(address, port).start();
 
         new CommandLineInput().run();
     }
 
     private final ServerSocket serverSocket;
 
-    public MultiPaperServer(int port) throws IOException {
-        serverSocket = new ServerSocket(port);
+    public MultiPaperServer(InetAddress address, int port) throws IOException {
+        serverSocket = new ServerSocket(port, 0, address);
 
         System.out.println("[MultiPaperMaster] Listening on " + serverSocket.getLocalSocketAddress());
     }

--- a/MultiPaper-Master/src/main/java/puregero/multipaper/server/bungee/MultiPaperProxy.java
+++ b/MultiPaper-Master/src/main/java/puregero/multipaper/server/bungee/MultiPaperProxy.java
@@ -15,6 +15,7 @@ import puregero.multipaper.server.ServerConnection;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -56,7 +57,7 @@ public class MultiPaperProxy extends Plugin implements Listener {
             balanceNodes = configuration.getBoolean("balanceNodes", true);
 
             try {
-                new MultiPaperServer(configuration.getInt("port")).start();
+                new MultiPaperServer(InetAddress.getByName("0.0.0.0"), configuration.getInt("port")).start();
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
```
minecraft@clean:~/multipaper_dev/master$ java -Xmx4G -Xms4G -jar MultiPaper-Master-2.6.4.jar 127.0.0.1:35353
[MultiPaperMaster] Listening on /127.0.0.1:35353
```

IP address is optional, defaults to `0.0.0.0` when only a port is defined.